### PR TITLE
게시글 삭제가 즉시 반영이 되지 않는 버그

### DIFF
--- a/src/components/PostTable.jsx
+++ b/src/components/PostTable.jsx
@@ -29,22 +29,18 @@ function PostTable() {
 
   useEffect(() => {
 
-    async function getPosts() {
-      setLoading(true);
-      await dispatch(fetchPosts({
-          page: pageInfo.page,
-          size: pageInfo.size,
-          sort: pageInfo.sort,
-          category: searchParams.get("category") === "ALL" ? null : searchParams.get("category"),
-          keyword: searchParams.get("keyword"),
-        })
-      );
-    }
+    setLoading(true);
+    dispatch(fetchPosts({
+        page: pageInfo.page,
+        size: pageInfo.size,
+        sort: pageInfo.sort,
+        category: searchParams.get("category") === "ALL" ? null : searchParams.get("category"),
+        keyword: searchParams.get("keyword"),
+      })
+    ).then(() => {
+      setLoading(false);
+    });
 
-    getPosts()
-      .then(() => {
-        setLoading(false);
-      });
   }, [searchParams]);
 
   const createdSortHandler = () => {

--- a/src/pages/PostDetailPage.jsx
+++ b/src/pages/PostDetailPage.jsx
@@ -76,8 +76,10 @@ const PostDetailPage = () => {
 
   const onDeleteHandler = () => {
     if (window.confirm("정말로 삭제하시겠습니까?")) {
-      dispatch(deletePost(id, userAuth.accessToken));
-      navigate(-1);
+      dispatch(deletePost(id, userAuth.accessToken))
+        .then(() => {
+          navigate(-1);
+        });
     }
   }
 


### PR DESCRIPTION
해당 버그는 게시글 삭제 API가 완료되기 전에, 페이지 이동으로 인해 게시글 목록을 가져와서 생긴 버그입니다.
게시글이 모두 삭제된 뒤에 게시글 목록을 가져오도록 수정하였습니다.
